### PR TITLE
Emoji class in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,4 +1,3 @@
-STAFF_EMOJI = '<:staff:884477446018199552>'
 PREFIXES = ['<', '?']
 STATUS = 'my dms'
 
@@ -9,3 +8,8 @@ LOG_CHANNELS = {
     'event_errors': 888368018915209236,
     'add_remove': 889116736077570068
 }
+
+
+class Emojis:
+    def __init__(self):
+        self.staff = '<:staff:884477446018199552>'

--- a/utils/bot.py
+++ b/utils/bot.py
@@ -3,7 +3,7 @@ import discord
 import logging
 from dotenv import load_dotenv
 from discord.ext import commands
-from config import PREFIXES, STATUS
+from config import PREFIXES, STATUS, Emojis
 from utils.database import Database
 from handler import InteractionClient
 
@@ -23,6 +23,7 @@ class ModMail(commands.AutoShardedBot):
         )
         self.app_client = InteractionClient(self)
         self.mongo = Database(os.getenv('DATABASE_LINK'))
+        self.emojis_ = Emojis()
         self.load_extension("jishaku")
         self.load_cogs("./cogs")
         self.add_check(self.blacklist_check)


### PR DESCRIPTION
this way you can access all emojis without importing anything like `self.bot.emojis_.staff`
the attr is `emojis_` cuz `emojis` is already a default one in the bot class 